### PR TITLE
Feat/paiza 5246 update ui notes template

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const Botkit = require('botkit');
-const request = require('request')
+const request = require('request');
+const dateutils = require('date-utils');
 
 if (!process.env.TOKEN) {
   console.log('Error: Specify TOKEN in environment');
@@ -79,20 +80,24 @@ controller.hears('', hearing_event_all, function(bot,message) {
       const bot_room = 'ui_notes'
       const key_word_matcher = '^title:.*'
       const title_matcher = '^title:([^\n]*)'
-      var msg = message["text"];
+      const dt = new Date();
+      const posted_at = '### 投稿日\n'+dt.toFormat("YYYY/MM/DD/ HH24:MI")+'\n';
+      const msg_url = '### Slack URL\nhttps://paiza.slack.com/archives/C8RRSA2CS/p'+message['event_ts']+'\n'
+      const msg = message["text"]
+      const trello_body = '###概要\n'+message["text"].replace( /^title:/g, '')+'\n';
+      var img_url = ''
 
-
+      var desc = encodeURIComponent(msg+msg_url+posted_at+img_url);
       if (channel_name.match(bot_room)){
         if(msg.match(key_word_matcher)){
-          if(message["files"]==null){
-            var img_url = ""
-          }else{
-            var img_url = message["files"][0]["url_private"];
-          };
+          if(message["files"]){
+            img_url = '### 画像URL\n' + message["files"][0]["url_private"]+'\n'
+          }
           var title = encodeURIComponent(msg.match(title_matcher)[1]);
-          var desc = encodeURIComponent(msg+'\n'+img_url);
+          var desc = encodeURIComponent(trello_body+msg_url+posted_at+img_url);
           var url = `https://trello.com/1/cards?key=${key}&token=${token}&idList=${list_new_id}&name=${title}&desc=${desc}`;
           var webclient = require("request");
+
           webclient.post({
             url: url,
             headers: {
@@ -101,7 +106,6 @@ controller.hears('', hearing_event_all, function(bot,message) {
           }, function (error, response, body){});
 
           bot.reply(message,"uiチームのタスクに登録されました。随時取り掛かります。" +'\n' + "https://trello.com/b/jrmkblAB/uinotes")
-
         };
       };
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const Botkit = require('botkit');
-const request = require('request');
-const dateutils = require('date-utils');
+const Botkit    = require('botkit');
+const request   = require('request');
+const require('date-utils');
 
 if (!process.env.TOKEN) {
   console.log('Error: Specify TOKEN in environment');
@@ -73,19 +73,19 @@ controller.hears('', hearing_event_all, function(bot,message) {
         repost_to('#日報_all', bot, post_link, message);
       }
 
-      const key = process.env.TRELLO_KEY;
-      const token=process.env.TRELLO_TOKEN;
-      const ui_note=process.env.TRELLO_UI_NOTE;
-      const list_new_id=process.env.TRELLO_LIST_NEW_ID;
-      const bot_room = 'ui_notes'
+      const key         = process.env.TRELLO_KEY;
+      const token       = process.env.TRELLO_TOKEN;
+      const ui_note     = process.env.TRELLO_UI_NOTE;
+      const list_new_id = process.env.TRELLO_LIST_NEW_ID;
+      const bot_room         = 'ui_notes'
       const key_word_matcher = '^title:.*'
-      const title_matcher = '^title:([^\n]*)'
-      const dt = new Date();
-      const posted_at = '### 投稿日\n'+dt.toFormat("YYYY/MM/DD/ HH24:MI")+'\n';
-      const msg_url = '### Slack URL\nhttps://paiza.slack.com/archives/C8RRSA2CS/p'+message['event_ts']+'\n'
-      const msg = message["text"]
-      const trello_body = '###概要\n'+message["text"].replace( /^title:/g, '')+'\n';
-      var img_url = ''
+      const title_matcher    = '^title:([^\n]*)'
+      const dt               = new Date();
+      const posted_at        = '### 投稿日\n'+dt.toFormat("YYYY/MM/DD/ HH24:MI")+'\n';
+      const msg_url          = '### Slack URL\nhttps://paiza.slack.com/archives/C8RRSA2CS/p'+message['event_ts']+'\n'
+      const msg              = message["text"]
+      const trello_body      = '###概要\n'+message["text"].replace( /^title:/g, '')+'\n';
+      var img_url            = ''
 
       var desc = encodeURIComponent(msg+msg_url+posted_at+img_url);
       if (channel_name.match(bot_room)){
@@ -93,9 +93,9 @@ controller.hears('', hearing_event_all, function(bot,message) {
           if(message["files"]){
             img_url = '### 画像URL\n' + message["files"][0]["url_private"]+'\n'
           }
-          var title = encodeURIComponent(msg.match(title_matcher)[1]);
-          var desc = encodeURIComponent(trello_body+msg_url+posted_at+img_url);
-          var url = `https://trello.com/1/cards?key=${key}&token=${token}&idList=${list_new_id}&name=${title}&desc=${desc}`;
+          var title     = encodeURIComponent(msg.match(title_matcher)[1]);
+          var desc      = encodeURIComponent(trello_body+msg_url+posted_at+img_url);
+          var url       = `https://trello.com/1/cards?key=${key}&token=${token}&idList=${list_new_id}&name=${title}&desc=${desc}`;
           var webclient = require("request");
 
           webclient.post({

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "yukimura1227 <takamura1227@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "botkit": "0.7.4"
+    "botkit": "0.7.4",
+    "date-utils": "^1.2.21"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,6 +1027,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-utils@^1.2.21:
+  version "1.2.21"
+  resolved "https://registry.yarnpkg.com/date-utils/-/date-utils-1.2.21.tgz#61fb16cdc1274b3c9acaaffe9fc69df8720a2b64"
+  integrity sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=
+
 debug@2.6.9, debug@^2.2, debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
feat: trelloの登録するカードの概要にsalck urlや投稿日を追加。テンプレもアップデートした。

下記のようにアプデした
```
---------------------------------
概要
XXXXXXXXXXXXX

Slack URL
https://paiza.slack.com/archives/C8RRSA2CS/XXXXXXXXXXXX

投稿日
2020/08/03/ 19:53

画像URL
https://files.slack.com/files-pri/XXXXXXXXXXXXXXXXX
---------------------------------
```

# JIRA
https://paiza2.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=PAIZA&modal=detail&selectedIssue=PAIZA-5246