### PR TITLE
fix: retry connection max 3 times when rtm closed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ if (!process.env.SLACK_TEAM) {
 }
 
 const controller = Botkit.slackbot({
-  debug: false
+  debug: false,
+  retry: 3,
 });
 
 controller.spawn({


### PR DESCRIPTION
RTMの接続が切れた際に復帰せずそのまま死ぬので3回を上限にretryオプションを追加